### PR TITLE
Convert style files to strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 var templateUrlRegex = /templateUrl *:(.*)$/gm;
 var stylesRegex = /styleUrls *:(\s*\[[^\]]*?\])/g;
 var stringRegex = /(['"])((?:[^\\]\\\1|.)*?)\1/g;
+var requireRegex = /(require\(.+?\))/g;
 
 function replaceStringsWithRequires(string) {
   return string.replace(stringRegex, function (match, quote, url) {
@@ -10,6 +11,12 @@ function replaceStringsWithRequires(string) {
     }
     return "require('" + url + "')";
   });
+}
+
+function addToString(string){
+  return string.replace(requireRegex, function(match) {
+    return match + ".toString()";
+  })
 }
 
 module.exports = function(source, sourcemap) {
@@ -24,7 +31,7 @@ module.exports = function(source, sourcemap) {
                .replace(stylesRegex, function (match, urls) {
                  // replace: stylesUrl: ['./foo.css', "./baz.css", "./index.component.css"]
                  // with: styles: [require('./foo.css'), require("./baz.css"), require("./index.component.css")]
-                 return "styles:" + replaceStringsWithRequires(urls);
+                 return "styles:" + addToString(replaceStringsWithRequires(urls));
                });
 
   // Support for tests

--- a/test/loader.spec.js
+++ b/test/loader.spec.js
@@ -15,7 +15,7 @@ describe("loader", function() {
   @Component({
     selector: 'test-component',
     template: require('./some/path/to/file.html'),
-    styles: [require('./app/css/styles.css')]
+    styles: [require('./app/css/styles.css').toString()]
   })
   export class TestComponent {}
 `
@@ -34,7 +34,7 @@ describe("loader", function() {
   @Component({
     selector: 'test-component',
     template: require('./some/path/to/file\'.html'),
-    styles: [require('./app/css/\"styles\".css\\')]
+    styles: [require('./app/css/\"styles\".css\\').toString()]
   })
   export class TestComponent {}
 `
@@ -54,8 +54,8 @@ describe("loader", function() {
     selector: 'test-component',
     template: require('./some/path/to/file.html'),
     styles: [
-      require('./app/css/styles.css'),
-      require('./app/css/more-styles.css')
+      require('./app/css/styles.css').toString(),
+      require('./app/css/more-styles.css').toString()
     ]
   })
   export class TestComponent {}
@@ -88,7 +88,7 @@ describe("loader", function() {
   @Component({
     selector: 'test-component',
     template: require('./file.html'),
-    styles: [require('./styles.css')]
+    styles: [require('./styles.css').toString()]
   })
   export class TestComponent {}
 `
@@ -106,7 +106,7 @@ describe("loader", function() {
   @Component({
     selector : 'test-component',
     template: require('./some/path/to/file.html'),
-    styles: [require('./app/css/styles.css')]
+    styles: [require('./app/css/styles.css').toString()]
   })
   export class TestComponent {}
 `


### PR DESCRIPTION
Instead of having to specify css loaders to be "to-string!css" you can now use just "css" and the conversion to string is done internally. Now the rest of your app can use regular css loaders instead of being strings. Impacts for example angular2-seed where they use `{ test: /\.css$/, loaders: ['to-string-loader', 'css-loader'] }`. It can now be simplified to just `{ test: /\.css$/, loaders: ['css-loader'] }`