### PR TITLE
Do not add missing "./" to relative path.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,9 +5,6 @@ var stringRegex = /(['"])((?:[^\\]\\\1|.)*?)\1/g;
 
 function replaceStringsWithRequires(string) {
   return string.replace(stringRegex, function (match, quote, url) {
-    if (url.charAt(0) !== ".") {
-      url = "./" + url;
-    }
     return "require('" + url + "')";
   });
 }

--- a/test/loader.spec.js
+++ b/test/loader.spec.js
@@ -78,7 +78,7 @@ describe("loader", function() {
       .eql(`template: require('./index/app.html')`);
   });
 
-  it("Should handle the absense of proper relative path notation", function() {
+  it("Shouldn't handle the absense of proper relative path notation", function() {
     loader.call({}, fixtures.componentWithoutRelPeriodSlash)
       .should
       .be
@@ -87,8 +87,8 @@ describe("loader", function() {
 
   @Component({
     selector: 'test-component',
-    template: require('./file.html'),
-    styles: [require('./styles.css')]
+    template: require('file.html'),
+    styles: [require('styles.css')]
   })
   export class TestComponent {}
 `


### PR DESCRIPTION
I don't really think that implicitly adding "./" to the module path is a good idea. In my opinion it is much better to let webpack handle this task (resolving module path). By default webpack looks for module with relative path through the all resolve.root[] places (which is very usefull for me), but when we add "./" implicitly, it removes such abilities. 