### PR TITLE
Avoid to append ./ automatically

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,9 +5,9 @@ var stringRegex = /(['"])((?:[^\\]\\\1|.)*?)\1/g;
 
 function replaceStringsWithRequires(string) {
   return string.replace(stringRegex, function (match, quote, url) {
-    if (url.charAt(0) !== ".") {
-      url = "./" + url;
-    }
+    //if (url.charAt(0) !== ".") {
+    //  url = "./" + url;
+    //}
     return "require('" + url + "')";
   });
 }


### PR DESCRIPTION
Currently, due to `./` being appended automatically to any file, it's not possible to resolve node_modules for example.

Will solve https://github.com/TheLarkInn/angular2-template-loader/issues/31

Could break other projects which are not appending `./` for resolving local files.
