### PR TITLE
Move codecov to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,12 +28,12 @@
   },
   "homepage": "https://github.com/TheLarkInn/angular2-template-loader#readme",
   "devDependencies": {
+    "codecov": "^1.0.1",
     "istanbul": "^0.4.3",
     "mocha": "^2.5.3",
     "should": "^9.0.0"
   },
   "dependencies": {
-    "codecov": "^1.0.1",
     "loader-utils": "^0.2.15"
   }
 }


### PR DESCRIPTION
Aims to close #27 

[codecov/codecov-node](https://github.com/codecov/codecov-node) has a long running issue  https://github.com/codecov/codecov-node/issues/8

It attempts to install node-gyp, which leads to issues with installation on Win platform.

As mentioned by @hyp3rdino, codecov is not used in the npm distribution, so it can be safely moved to devDependencies.