### PR TITLE
Adding type assertion <string> option to fix issues with typescript type checks

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,26 +17,18 @@ function replaceStringsWithRequires(string, config) {
   });
 }
 
-/**
- * Loads loader config. Reads config from both query string
- * and new webpack2 loader options. Query takes precedence.
- */
-function getConfig(ctx) {
-
-  var query = ctx.query ? utils.parseQuery(ctx.query) : {};
-  var options = ctx.options ? ctx.options['angular2Template'] : {};
-
-  delete query.config;
-
-  return assign({}, options, query);
-}
 
 module.exports = function(source, sourcemap) {
   // Not cacheable during unit tests;
   this.cacheable && this.cacheable();
 
+  // getLoaderConfig expects options to be always set
+  if(!this.options){
+    this.options = {}
+  }
+
   // Reads config
-  var config = getConfig(this);
+  var config = utils.getLoaderConfig(this, 'angular2Template');
 
   var newSource = source.replace(templateUrlRegex, function (match, url) {
                  // replace: templateUrl: './path/to/template.html'

--- a/index.js
+++ b/index.js
@@ -1,30 +1,52 @@
+var utils = require('loader-utils');
+var assign = require('object-assign');
 // using: regex, capture groups, and capture group variables.
 var templateUrlRegex = /templateUrl *:(.*)$/gm;
 var stylesRegex = /styleUrls *:(\s*\[[^\]]*?\])/g;
 var stringRegex = /(['"])((?:[^\\]\\\1|.)*?)\1/g;
 
-function replaceStringsWithRequires(string) {
+function replaceStringsWithRequires(string, config) {
+  // Defaults type assertion inclusion <string> to false for now
+  var typeAssertion = config.hasOwnProperty('typeAssertion') ? config.typeAssertion : false;
+
   return string.replace(stringRegex, function (match, quote, url) {
     if (url.charAt(0) !== ".") {
       url = "./" + url;
     }
-    return "require('" + url + "')";
+    return (typeAssertion ? "<string>" : "") + "require('" + url + "')";
   });
+}
+
+/**
+ * Loads loader config. Reads config from both query string
+ * and new webpack2 loader options. Query takes precedence.
+ */
+function getConfig(ctx) {
+
+  var query = ctx.query ? utils.parseQuery(ctx.query) : {};
+  var options = ctx.options ? ctx.options['angular2Template'] : {};
+
+  delete query.config;
+
+  return assign({}, options, query);
 }
 
 module.exports = function(source, sourcemap) {
   // Not cacheable during unit tests;
   this.cacheable && this.cacheable();
 
+  // Reads config
+  var config = getConfig(this);
+
   var newSource = source.replace(templateUrlRegex, function (match, url) {
                  // replace: templateUrl: './path/to/template.html'
                  // with: template: require('./path/to/template.html')
-                 return "template:" + replaceStringsWithRequires(url);
+                 return "template:" + replaceStringsWithRequires(url, config);
                })
                .replace(stylesRegex, function (match, urls) {
                  // replace: stylesUrl: ['./foo.css', "./baz.css", "./index.component.css"]
                  // with: styles: [require('./foo.css'), require("./baz.css"), require("./index.component.css")]
-                 return "styles:" + replaceStringsWithRequires(urls);
+                 return "styles:" + replaceStringsWithRequires(urls, config);
                });
 
   // Support for tests

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "should": "^9.0.0"
   },
   "dependencies": {
-    "loader-utils": "^0.2.15"
+    "loader-utils": "^0.2.15",
+    "object-assign": "^4.1.0"
   }
 }

--- a/test/loader.spec.js
+++ b/test/loader.spec.js
@@ -114,4 +114,119 @@ describe("loader", function() {
 
   });
 
+  it("Should convert html and style file strings adding type assetion when typeAssetion option is true", function() {
+    var ctx = {
+      options: {
+        angular2Template : {
+          typeAssertion : true
+        }
+      }
+    };
+    loader.call(ctx, fixtures.componentWithSpacing)
+      .should
+      .be
+      .eql(`
+  import {Component} from '@angular/core';
+
+  @Component({
+    selector : 'test-component',
+    template: <string>require('./some/path/to/file.html'),
+    styles: [<string>require('./app/css/styles.css')]
+  })
+  export class TestComponent {}
+`)
+
+  });
+
+  it("Should convert html and style file strings adding type assetion when typeAssetion query param is true", function() {
+    var ctx = {
+      query: '?typeAssertion=true'
+    };
+    loader.call(ctx, fixtures.componentWithSpacing)
+      .should
+      .be
+      .eql(`
+  import {Component} from '@angular/core';
+
+  @Component({
+    selector : 'test-component',
+    template: <string>require('./some/path/to/file.html'),
+    styles: [<string>require('./app/css/styles.css')]
+  })
+  export class TestComponent {}
+`)
+
+  });
+
+  it("Should convert html and style file strings adding type assetion and query should take precedence", function() {
+    var ctx = {
+      query: '?typeAssertion=true',
+      options: {
+        angular2Template : {
+          typeAssertion : false
+        }
+      }
+    };
+    loader.call(ctx, fixtures.componentWithSpacing)
+      .should
+      .be
+      .eql(`
+  import {Component} from '@angular/core';
+
+  @Component({
+    selector : 'test-component',
+    template: <string>require('./some/path/to/file.html'),
+    styles: [<string>require('./app/css/styles.css')]
+  })
+  export class TestComponent {}
+`)
+
+  });
+
+
+  it("Should convert html and style file strings NOT adding type assetion when typeAssetion option is false", function() {
+    var ctx = {
+      options: {
+        angular2Template : {
+          typeAssertion : false
+        }
+      }
+    };
+    loader.call(ctx, fixtures.componentWithSpacing)
+      .should
+      .be
+      .eql(`
+  import {Component} from '@angular/core';
+
+  @Component({
+    selector : 'test-component',
+    template: require('./some/path/to/file.html'),
+    styles: [require('./app/css/styles.css')]
+  })
+  export class TestComponent {}
+`)
+
+  });
+
+  it("Should convert html and style file strings NOT adding type assetion when typeAssetion query param is false", function() {
+    var ctx = {
+      query: '?typeAssertion=false'
+    };
+    loader.call(ctx, fixtures.componentWithSpacing)
+      .should
+      .be
+      .eql(`
+  import {Component} from '@angular/core';
+
+  @Component({
+    selector : 'test-component',
+    template: require('./some/path/to/file.html'),
+    styles: [require('./app/css/styles.css')]
+  })
+  export class TestComponent {}
+`)
+
+  });
+
+
 });

--- a/test/loader.spec.js
+++ b/test/loader.spec.js
@@ -114,7 +114,7 @@ describe("loader", function() {
 
   });
 
-  it("Should convert html and style file strings adding type assetion when typeAssetion option is true", function() {
+  it("Should convert html and style file strings adding type assertion when typeAssertion option is true", function() {
     var ctx = {
       options: {
         angular2Template : {
@@ -138,7 +138,7 @@ describe("loader", function() {
 
   });
 
-  it("Should convert html and style file strings adding type assetion when typeAssetion query param is true", function() {
+  it("Should convert html and style file strings adding type assertion when typeAssertion query param is true", function() {
     var ctx = {
       query: '?typeAssertion=true'
     };
@@ -158,7 +158,7 @@ describe("loader", function() {
 
   });
 
-  it("Should convert html and style file strings adding type assetion and query should take precedence", function() {
+  it("Should convert html and style file strings adding type assertion and query should take precedence", function() {
     var ctx = {
       query: '?typeAssertion=true',
       options: {
@@ -184,7 +184,7 @@ describe("loader", function() {
   });
 
 
-  it("Should convert html and style file strings NOT adding type assetion when typeAssetion option is false", function() {
+  it("Should convert html and style file strings NOT adding type assertion when typeAssertion option is false", function() {
     var ctx = {
       options: {
         angular2Template : {
@@ -208,7 +208,7 @@ describe("loader", function() {
 
   });
 
-  it("Should convert html and style file strings NOT adding type assetion when typeAssetion query param is false", function() {
+  it("Should convert html and style file strings NOT adding type assertion when typeAssertion query param is false", function() {
     var ctx = {
       query: '?typeAssertion=false'
     };


### PR DESCRIPTION
Typescript complains about the return type of the require() function once A2 defines the component template field as type string. The correct A2 component annotation should be as follows:

```
@Component({
  selector: 'my-component',
  template: <string> require('./my-template.html'),
  styles: [<string> require('./my-style.css')]
})
```

This adds an option to include `typeAssertion` to the require() generation. It supports both passing it as a query param `angular2-template-loader?typeAssertion=true` or the via options plugin supported by Webpack 2. Right now, it leaves the type assertion inclusion defaulted to `false`. But I think it should be defaulted to `true` in a near future.
