### PR TITLE
remove useWebpackText section from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Chain-to loader for webpack that inlines all html and style's in angular2 compon
 - [Installation](#installation)
 - [Requirements](#requirements)
 - [Example markup](#example-markup)
-- [Awesome Typescript Loader](#awesome-typescript-loader)
 - [How does it work](#how-does-it-work)
 
 ### Installation
@@ -52,23 +51,6 @@ module: {
       loader: 'raw-loader'
     }
   ]
-}
-```
-
-### Awesome Typescript Loader
-When using `awesome-typescript-loader` to load your typescript files you have to set the `useWebpackText` property to `true`.
-Otherwise the `angular2-template-loader` is not able to chain into it.
-
-Here is an example markup (`tsconfig.json`)
-```js
-{
-  "compilerOptions": {
-    ...
-  },
-  "awesomeTypescriptLoaderOptions": {
-    ...
-    "useWebpackText": true // Allows other loaders to be chained to awesome-typescript-loader.
-  },
 }
 ```
 


### PR DESCRIPTION
Since `useWebpackText` was removed from `awesome-typescript-loader`.
This section might be redundant.