### PR TITLE
Added `keepUrl` query option allowing users to use `file-loader`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,19 @@ module: {
   loaders: [
     {
       test: /\.ts$/,
-      loaders: ['awesome-typescript-loader', 'angular2-template-loader'],
+      loaders: ['awesome-typescript-loader', 'angular2-template-loader?keepUrl=true'],
       exclude: [/\.(spec|e2e)\.ts$/]
     },
+    /* Embed files. */
     { 
       test: /\.(html|css)$/, 
-      loader: 'raw-loader'
+      loader: 'raw-loader',
+      exclude: /\.async\.(html|css)$/
+    },
+    /* Async loading. */
+    {
+      test: /\.async\.(html|css)$/, 
+      loaders: ['file?name=[name].[hash].[ext]', 'extract']
     }
   ]
 }
@@ -74,5 +81,6 @@ Here is an example markup (`tsconfig.json`)
 
 ### How does it work
 The `angular2-template-loader` searches for `templateUrl` and `styleUrls` declarations inside of the Angular 2 Component metadata and replaces the paths with the corresponding `require` statement.
+If `keepUrl=true` is added to the loader's query string, `templateUrl` and `styleUrls` will not be replaced by `template` and `style` respectively so you can use a loader like `file-loader`.
 
 The generated `require` statements will be handled by the given loader for `.html` and `.js` files.

--- a/index.js
+++ b/index.js
@@ -17,11 +17,18 @@ function replaceStringsWithRequires(string) {
 
 module.exports = function(source, sourcemap) {
 
+  var config = {};
   var query = loaderUtils.parseQuery(this.query);
   var styleProperty = 'styles';
   var templateProperty = 'template';
 
-  if (query.keepUrl === true) {
+  if (this.options != null) {
+    Object.assign(config, this.options['angular2TemplateLoader']);
+  }
+
+  Object.assign(config, query);
+
+  if (config.keepUrl === true) {
       styleProperty = 'styleUrls';
       templateProperty = 'templateUrl';
   }

--- a/index.js
+++ b/index.js
@@ -1,3 +1,6 @@
+
+var loaderUtils = require("loader-utils");
+
 // using: regex, capture groups, and capture group variables.
 var templateUrlRegex = /templateUrl *:(.*)$/gm;
 var stylesRegex = /styleUrls *:(\s*\[[^\]]*?\])/g;
@@ -13,18 +16,32 @@ function replaceStringsWithRequires(string) {
 }
 
 module.exports = function(source, sourcemap) {
-  // Not cacheable during unit tests;
+
+  var query = loaderUtils.parseQuery(this.query);
+  var styleProperty = 'styles';
+  var templateProperty = 'template';
+
+  if (query.keepUrl === true) {
+      styleProperty = 'styleUrls';
+      templateProperty = 'templateUrl';
+  }
+
+    // Not cacheable during unit tests;
   this.cacheable && this.cacheable();
 
   var newSource = source.replace(templateUrlRegex, function (match, url) {
                  // replace: templateUrl: './path/to/template.html'
                  // with: template: require('./path/to/template.html')
-                 return "template:" + replaceStringsWithRequires(url);
+                 // or: templateUrl: require('./path/to/template.html')
+                 // if `keepUrl` query parameter is set to true.
+                 return templateProperty + ":" + replaceStringsWithRequires(url);
                })
                .replace(stylesRegex, function (match, urls) {
                  // replace: stylesUrl: ['./foo.css', "./baz.css", "./index.component.css"]
                  // with: styles: [require('./foo.css'), require("./baz.css"), require("./index.component.css")]
-                 return "styles:" + replaceStringsWithRequires(urls);
+                 // or: styleUrls: [require('./foo.css'), require("./baz.css"), require("./index.component.css")]
+                 // if `keepUrl` query parameter is set to true.
+                 return styleProperty + ":" + replaceStringsWithRequires(urls);
                });
 
   // Support for tests

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -9,4 +9,3 @@ exports.componentWithQuoteInUrls = componentWithQuoteInUrls;
 exports.componentWithMultipleStyles = componentWithMultipleStyles;
 exports.componentWithoutRelPeriodSlash = componentWithoutRelPeriodSlash;
 exports.componentWithSpacing = componentWithSpacing;
-

--- a/test/loader.spec.js
+++ b/test/loader.spec.js
@@ -114,4 +114,23 @@ describe("loader", function() {
 
   });
 
+  it("Should keep templateUrl when asked for", function () {
+
+    loader.call({query: '?keepUrl=true'}, fixtures.componentWithSpacing)
+      .should
+      .be
+      .eql(`
+  import {Component} from '@angular/core';
+
+  @Component({
+    selector : 'test-component',
+    templateUrl: require('./some/path/to/file.html'),
+    styleUrls: [require('./app/css/styles.css')]
+  })
+  export class TestComponent {}
+`
+      )
+
+  });
+
 });

--- a/test/loader.spec.js
+++ b/test/loader.spec.js
@@ -129,7 +129,34 @@ describe("loader", function() {
   })
   export class TestComponent {}
 `
-      )
+      );
+
+  });
+
+  it("Should keep templateUrl when asked using options", function () {
+
+    var self = {};
+
+    self.options = {
+      angular2TemplateLoader: {
+        keepUrl: true
+      }
+    };
+
+    loader.call(self, fixtures.componentWithSpacing)
+        .should
+        .be
+        .eql(`
+  import {Component} from '@angular/core';
+
+  @Component({
+    selector : 'test-component',
+    templateUrl: require('./some/path/to/file.html'),
+    styleUrls: [require('./app/css/styles.css')]
+  })
+  export class TestComponent {}
+`
+        );
 
   });
 


### PR DESCRIPTION
Hi,

I just added a `keepUrl` option in order to disable the replacement of `templateUrl` with `template`.
This is useful to load files using `templateUrl` with `file-loader` in production and `template` with `raw-loader` while unit-testing.
For example, my webpack configuration loads templates using `file-loader` when named `async.html` and `raw-loader` if not and when unit-testing, all templates are loaded using `raw-loader`.

