### PR TITLE
Add assuring that exported is a string

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function replaceStringsWithRequires(string) {
     if (url.charAt(0) !== ".") {
       url = "./" + url;
     }
-    return "require('" + url + "')";
+    return "typeof require('" + url + "') === 'string' ? require('" + url + "') : ''";
   });
 }
 


### PR DESCRIPTION
I have met issue caused by using of ExtractTextPlugin with following error message:
```
Expected 'styleUrls' to be an array of strings.
```

Idea of my fix is an ensuring that each element of `styleUrls` is a string.
The result (in bundle) looks like:
```javascript
core_1.Component({
    ...
    styles: [typeof __webpack_require__(296) === 'string' ? __webpack_require__(296) : '']
    ...
})
```

I would not like to update tests untill your approval of solution.
Waiting for your response.
Thanks in advance.