### PR TITLE
Fix templateUrl regexp for the single line component decorator

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 var loaderUtils = require("loader-utils");
 
 // using: regex, capture groups, and capture group variables.
-var templateUrlRegex = /templateUrl *:(.*)$/gm;
+var templateUrlRegex = /templateUrl\s*:(\s*['"`](.*?)['"`]([,}\n]))/gm;
 var stylesRegex = /styleUrls *:(\s*\[[^\]]*?\])/g;
 var stringRegex = /(['"])((?:[^\\]\\\1|.)*?)\1/g;
 

--- a/test/fixtures/component_with_single_line_decorator.js
+++ b/test/fixtures/component_with_single_line_decorator.js
@@ -1,0 +1,8 @@
+var componentWithSingleLineDecorator = `
+  import {Component} from '@angular/core';
+
+  @Component({selector: 'test-component', templateUrl: './file.html', styleUrls: ['./styles.css']})
+  export class TestComponent {};
+`;
+
+module.exports = componentWithSingleLineDecorator;

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -3,9 +3,11 @@ var componentWithQuoteInUrls = require('./component_with_quote_in_urls.js');
 var componentWithMultipleStyles = require('./component_with_multiple_styles.js');
 var componentWithoutRelPeriodSlash = require('./component_without_relative_period_slash.js');
 var componentWithSpacing = require('./component_with_spacing.js');
+var componentWithSingleLineDecorator = require('./component_with_single_line_decorator.js');
 
 exports.simpleAngular2TestComponentFileStringSimple = sampleAngular2ComponentSimpleFixture;
 exports.componentWithQuoteInUrls = componentWithQuoteInUrls;
 exports.componentWithMultipleStyles = componentWithMultipleStyles;
 exports.componentWithoutRelPeriodSlash = componentWithoutRelPeriodSlash;
 exports.componentWithSpacing = componentWithSpacing;
+exports.componentWithSingleLineDecorator = componentWithSingleLineDecorator;

--- a/test/loader.spec.js
+++ b/test/loader.spec.js
@@ -72,10 +72,10 @@ describe("loader", function() {
   });
 
   it("Should convert partial string match requires", function() {
-    loader.call({}, `templateUrl: './index/app.html'`)
+    loader.call({}, `{templateUrl: './index/app.html'}`)
       .should
       .be
-      .eql(`template: require('./index/app.html')`);
+      .eql(`{template: require('./index/app.html')}`);
   });
 
   it("Should handle the absense of proper relative path notation", function() {
@@ -157,6 +157,21 @@ describe("loader", function() {
   export class TestComponent {}
 `
         );
+
+  });
+
+  it("Should convert html and style file strings to require()s in a single line component decorator", function() {
+
+    loader.call({}, fixtures.componentWithSingleLineDecorator)
+      .should
+      .be
+      .eql(`
+  import {Component} from '@angular/core';
+
+  @Component({selector: 'test-component', template: require('./file.html'), styles: [require('./styles.css')]})
+  export class TestComponent {};
+`
+      );
 
   });
 


### PR DESCRIPTION
I have found that if you want to pass parameters to the @Component decorator in a single line you will get the following error:
```javascript
Uncaught ReferenceError: require is not defined
```
It's caused by incorrect templateUrlRegex which converts
```javascript
@Component({selector: 'my-app', templateUrl: './app.component.html', styleUrls: ['./app.component.css']})
export class AppComponent { };
```
to the following code:
```javascript
@Component({selector: 'my-app', template: require('./app.component.html'), styles: [require(require('./app.component.css'))]})
export class AppComponent { };
```