### PR TITLE
Fix regexp for cases when templateUrl line is ending by space character

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,9 @@
 var loaderUtils = require("loader-utils");
 
 // using: regex, capture groups, and capture group variables.
-var templateUrlRegex = /templateUrl\s*:(\s*['"`](.*?)['"`]([,}\n]))/gm;
+var templateUrlRegex = /templateUrl\s*:(\s*['"`](.*?)['"`]\s*([,}]))/gm;
 var stylesRegex = /styleUrls *:(\s*\[[^\]]*?\])/g;
-var stringRegex = /(['"])((?:[^\\]\\\1|.)*?)\1/g;
+var stringRegex = /(['`"])((?:[^\\]\\\1|.)*?)\1/g;
 
 function replaceStringsWithRequires(string) {
   return string.replace(stringRegex, function (match, quote, url) {

--- a/test/fixtures/component_with_template_url_ending_by_space.js
+++ b/test/fixtures/component_with_template_url_ending_by_space.js
@@ -1,0 +1,12 @@
+var componentWithTemplateUrlEndingBySpace = `
+  import {Component} from '@angular/core';
+
+  @Component({
+    selector: 'test-component',
+    templateUrl: './some/path/to/file.html', 
+    styleUrls: ['./app/css/styles.css'] 
+  })
+  export class TestComponent {}
+`;
+
+module.exports = componentWithTemplateUrlEndingBySpace;

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -4,6 +4,7 @@ var componentWithMultipleStyles = require('./component_with_multiple_styles.js')
 var componentWithoutRelPeriodSlash = require('./component_without_relative_period_slash.js');
 var componentWithSpacing = require('./component_with_spacing.js');
 var componentWithSingleLineDecorator = require('./component_with_single_line_decorator.js');
+var componentWithTemplateUrlEndingBySpace = require('./component_with_template_url_ending_by_space.js');
 
 exports.simpleAngular2TestComponentFileStringSimple = sampleAngular2ComponentSimpleFixture;
 exports.componentWithQuoteInUrls = componentWithQuoteInUrls;
@@ -11,3 +12,4 @@ exports.componentWithMultipleStyles = componentWithMultipleStyles;
 exports.componentWithoutRelPeriodSlash = componentWithoutRelPeriodSlash;
 exports.componentWithSpacing = componentWithSpacing;
 exports.componentWithSingleLineDecorator = componentWithSingleLineDecorator;
+exports.componentWithTemplateUrlEndingBySpace = componentWithTemplateUrlEndingBySpace;

--- a/test/loader.spec.js
+++ b/test/loader.spec.js
@@ -175,4 +175,23 @@ describe("loader", function() {
 
   });
 
+  it("Should convert html and style file strings to require()s if line is ending by space character", function() {
+
+    loader.call({}, fixtures.componentWithTemplateUrlEndingBySpace)
+      .should
+      .be
+      .eql(`
+  import {Component} from '@angular/core';
+
+  @Component({
+    selector: 'test-component',
+    template: require('./some/path/to/file.html'), 
+    styles: [require('./app/css/styles.css')] 
+  })
+  export class TestComponent {}
+`
+      )
+
+  });
+
 });


### PR DESCRIPTION
Seems like previous regexep didn't parse templateUrl line which ending by space character. resolve #50 