### PR TITLE
Update naming according to the Angular presskit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # angular2-template-loader
-Chain-to loader for webpack that inlines all html and style's in angular2 components.
+Chain-to loader for webpack that inlines all html and style's in angular components.
 
 [![Build Status](https://travis-ci.org/TheLarkInn/angular2-template-loader.svg?branch=master)](https://travis-ci.org/TheLarkInn/angular2-template-loader)
 [![Coverage](https://codecov.io/gh/TheLarkInn/angular2-template-loader/branch/master/graph/badge.svg)](https://codecov.io/gh/TheLarkInn/angular2-template-loader)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "angular2-template-loader",
   "version": "0.6.2",
-  "description": "Angular2 webpack loader that inlines your angular2 templates and stylesheets into angular components.  ",
+  "description": "Angular webpack loader that inlines your angular templates and stylesheets into angular components.  ",
   "main": "index.js",
   "scripts": {
     "test": "mocha --reporter spec",
@@ -16,7 +16,7 @@
     "url": "git+https://github.com/TheLarkInn/angular2-template-loader.git"
   },
   "keywords": [
-    "angular2",
+    "angular",
     "webpack",
     "angularjs",
     "loader",

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -1,4 +1,4 @@
-var sampleAngular2ComponentSimpleFixture = require('./sample_angular2_component_file_string_simple.js');
+var sampleAngularComponentSimpleFixture = require('./sample_angular_component_file_string_simple.js');
 var componentWithQuoteInUrls = require('./component_with_quote_in_urls.js');
 var componentWithMultipleStyles = require('./component_with_multiple_styles.js');
 var componentWithoutRelPeriodSlash = require('./component_without_relative_period_slash.js');
@@ -6,7 +6,7 @@ var componentWithSpacing = require('./component_with_spacing.js');
 var componentWithSingleLineDecorator = require('./component_with_single_line_decorator.js');
 var componentWithTemplateUrlEndingBySpace = require('./component_with_template_url_ending_by_space.js');
 
-exports.simpleAngular2TestComponentFileStringSimple = sampleAngular2ComponentSimpleFixture;
+exports.simpleAngularTestComponentFileStringSimple = sampleAngularComponentSimpleFixture;
 exports.componentWithQuoteInUrls = componentWithQuoteInUrls;
 exports.componentWithMultipleStyles = componentWithMultipleStyles;
 exports.componentWithoutRelPeriodSlash = componentWithoutRelPeriodSlash;

--- a/test/fixtures/sample_angular_component_file_string_simple.js
+++ b/test/fixtures/sample_angular_component_file_string_simple.js
@@ -1,4 +1,4 @@
-var simpleAngular2TestComponentFileStringSimple = `
+var simpleAngularTestComponentFileStringSimple = `
   import {Component} from '@angular/core';
 
   @Component({
@@ -9,4 +9,4 @@ var simpleAngular2TestComponentFileStringSimple = `
   export class TestComponent {}
 `;
 
-module.exports = simpleAngular2TestComponentFileStringSimple;
+module.exports = simpleAngularTestComponentFileStringSimple;

--- a/test/loader.spec.js
+++ b/test/loader.spec.js
@@ -6,7 +6,7 @@ var fixtures = require("./fixtures");
 describe("loader", function() {
   it("Should convert html and style file strings to require()s", function(){
 
-    loader.call({}, fixtures.simpleAngular2TestComponentFileStringSimple)
+    loader.call({}, fixtures.simpleAngularTestComponentFileStringSimple)
       .should
       .be
       .eql(`


### PR DESCRIPTION
Renamed `angular2` for the none-crucial parts accordingly to the Angular presskit and [#itsjustangular](https://twitter.com/hashtag/itsjustangular)