### PR TITLE
Make the ending comma/curlybrace after templateUrl optional.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 var loaderUtils = require("loader-utils");
 
 // using: regex, capture groups, and capture group variables.
-var templateUrlRegex = /templateUrl\s*:(\s*['"`](.*?)['"`]\s*([,}]))/gm;
+var templateUrlRegex = /templateUrl\s*:(\s*['"`](.*?)['"`]\s*([,}])?)/gm;
 var stylesRegex = /styleUrls *:(\s*\[[^\]]*?\])/g;
 var stringRegex = /(['`"])((?:[^\\]\\\1|.)*?)\1/g;
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 var loaderUtils = require("loader-utils");
 
 // using: regex, capture groups, and capture group variables.
-var templateUrlRegex = /templateUrl\s*:(\s*['"`](.*?)['"`]\s*([,}])?)/gm;
+var templateUrlRegex = /templateUrl\s*:(\s*['"`](.*?)([^\\]['"`])\s*)/gm;
 var stylesRegex = /styleUrls *:(\s*\[[^\]]*?\])/g;
 var stringRegex = /(['`"])((?:[^\\]\\\1|.)*?)\1/g;
 

--- a/test/fixtures/component_with_comment_after_template_url.js
+++ b/test/fixtures/component_with_comment_after_template_url.js
@@ -3,8 +3,7 @@ var componentWithCommentAfterTemplateUrl = `
 
   @Component({
     selector: 'test-component',
-    templateUrl: './some/path/to/file.html', /*my awesome template*/
-    styleUrls: ['./app/css/styles.css']
+    templateUrl: './some/path/to/file.html' /*my awesome template*/
   })
   export class TestComponent {}
 `;

--- a/test/fixtures/component_with_comment_after_template_url.js
+++ b/test/fixtures/component_with_comment_after_template_url.js
@@ -1,0 +1,12 @@
+var componentWithCommentAfterTemplateUrl = `
+  import {Component} from '@angular/core';
+
+  @Component({
+    selector: 'test-component',
+    templateUrl: './some/path/to/file.html', /*my awesome template*/
+    styleUrls: ['./app/css/styles.css']
+  })
+  export class TestComponent {}
+`;
+
+module.exports = componentWithCommentAfterTemplateUrl;

--- a/test/fixtures/component_with_comment_between_decorator_and_class.js
+++ b/test/fixtures/component_with_comment_between_decorator_and_class.js
@@ -1,0 +1,16 @@
+var componentWithCommentBetweenDecoratorAndClass = `
+  import {Component} from '@angular/core';
+
+  @Component({
+    selector: 'test-component',
+    templateUrl: './some/path/to/file.html',
+    styleUrls : ['./app/css/styles.css']
+  })
+
+  /*  
+   * Comment
+   */
+  export class TestComponent  { }
+`;
+
+module.exports = componentWithCommentBetweenDecoratorAndClass;

--- a/test/fixtures/component_with_only_template_url.js
+++ b/test/fixtures/component_with_only_template_url.js
@@ -1,0 +1,12 @@
+var componentWithOnlyTemplateUrl = `
+  import {Component} from '@angular/core';
+
+  @Component({
+    selector: 'test-component',
+    templateUrl: './some/path/to/file.html'
+    //styleUrls: ['./app/css/styles.css']
+  })
+  export class TestComponent {}
+`;
+
+module.exports = componentWithOnlyTemplateUrl;

--- a/test/fixtures/component_with_template_url_last.js
+++ b/test/fixtures/component_with_template_url_last.js
@@ -1,0 +1,12 @@
+var componentWithTemplateUrlLast = `
+  import {Component} from '@angular/core';
+
+  @Component({
+    selector: 'test-component',
+    styleUrls: ['./app/css/styles.css'],
+    templateUrl: './some/path/to/file.html'
+  })
+  export class TestComponent {}
+`;
+
+module.exports = componentWithTemplateUrlLast;

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -5,6 +5,7 @@ var componentWithoutRelPeriodSlash = require('./component_without_relative_perio
 var componentWithSpacing = require('./component_with_spacing.js');
 var componentWithSingleLineDecorator = require('./component_with_single_line_decorator.js');
 var componentWithTemplateUrlEndingBySpace = require('./component_with_template_url_ending_by_space.js');
+var componentWithTemplateUrlLast = require('./component_with_template_url_last.js');
 
 exports.simpleAngularTestComponentFileStringSimple = sampleAngularComponentSimpleFixture;
 exports.componentWithQuoteInUrls = componentWithQuoteInUrls;
@@ -13,3 +14,4 @@ exports.componentWithoutRelPeriodSlash = componentWithoutRelPeriodSlash;
 exports.componentWithSpacing = componentWithSpacing;
 exports.componentWithSingleLineDecorator = componentWithSingleLineDecorator;
 exports.componentWithTemplateUrlEndingBySpace = componentWithTemplateUrlEndingBySpace;
+exports.componentWithTemplateUrlLast = componentWithTemplateUrlLast;

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -6,8 +6,9 @@ var componentWithSpacing = require('./component_with_spacing.js');
 var componentWithSingleLineDecorator = require('./component_with_single_line_decorator.js');
 var componentWithTemplateUrlEndingBySpace = require('./component_with_template_url_ending_by_space.js');
 var componentWithTemplateUrlLast = require('./component_with_template_url_last.js');
-var componentWithCommentAfterTemplateUrl = require('./component_with_comment_after_template_url');
+var componentWithCommentAfterTemplateUrl = require('./component_with_comment_after_template_url.js');
 var componentWithCommentBetweenDecoratorAndClass = require('./component_with_comment_between_decorator_and_class.js');
+var componentWithOnlyTemplateUrl = require('./component_with_only_template_url.js');
 
 exports.simpleAngularTestComponentFileStringSimple = sampleAngularComponentSimpleFixture;
 exports.componentWithQuoteInUrls = componentWithQuoteInUrls;
@@ -19,3 +20,4 @@ exports.componentWithTemplateUrlEndingBySpace = componentWithTemplateUrlEndingBy
 exports.componentWithTemplateUrlLast = componentWithTemplateUrlLast;
 exports.componentWithCommentAfterTemplateUrl = componentWithCommentAfterTemplateUrl;
 exports.componentWithCommentBetweenDecoratorAndClass = componentWithCommentBetweenDecoratorAndClass;
+exports.componentWithOnlyTemplateUrl = componentWithOnlyTemplateUrl;

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -6,6 +6,7 @@ var componentWithSpacing = require('./component_with_spacing.js');
 var componentWithSingleLineDecorator = require('./component_with_single_line_decorator.js');
 var componentWithTemplateUrlEndingBySpace = require('./component_with_template_url_ending_by_space.js');
 var componentWithTemplateUrlLast = require('./component_with_template_url_last.js');
+var componentWithCommentAfterTemplateUrl = require('./component_with_comment_after_template_url');
 
 exports.simpleAngularTestComponentFileStringSimple = sampleAngularComponentSimpleFixture;
 exports.componentWithQuoteInUrls = componentWithQuoteInUrls;
@@ -15,3 +16,4 @@ exports.componentWithSpacing = componentWithSpacing;
 exports.componentWithSingleLineDecorator = componentWithSingleLineDecorator;
 exports.componentWithTemplateUrlEndingBySpace = componentWithTemplateUrlEndingBySpace;
 exports.componentWithTemplateUrlLast = componentWithTemplateUrlLast;
+exports.componentWithCommentAfterTemplateUrl = componentWithCommentAfterTemplateUrl;

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -7,6 +7,7 @@ var componentWithSingleLineDecorator = require('./component_with_single_line_dec
 var componentWithTemplateUrlEndingBySpace = require('./component_with_template_url_ending_by_space.js');
 var componentWithTemplateUrlLast = require('./component_with_template_url_last.js');
 var componentWithCommentAfterTemplateUrl = require('./component_with_comment_after_template_url');
+var componentWithCommentBetweenDecoratorAndClass = require('./component_with_comment_between_decorator_and_class.js');
 
 exports.simpleAngularTestComponentFileStringSimple = sampleAngularComponentSimpleFixture;
 exports.componentWithQuoteInUrls = componentWithQuoteInUrls;
@@ -17,3 +18,4 @@ exports.componentWithSingleLineDecorator = componentWithSingleLineDecorator;
 exports.componentWithTemplateUrlEndingBySpace = componentWithTemplateUrlEndingBySpace;
 exports.componentWithTemplateUrlLast = componentWithTemplateUrlLast;
 exports.componentWithCommentAfterTemplateUrl = componentWithCommentAfterTemplateUrl;
+exports.componentWithCommentBetweenDecoratorAndClass = componentWithCommentBetweenDecoratorAndClass;

--- a/test/loader.spec.js
+++ b/test/loader.spec.js
@@ -196,7 +196,7 @@ describe("loader", function() {
 
   it("Should convert templateUrl properties when they appear last.", function() {
 
-    loader.call({}, fixtures.componentWithTemplateUrlEndingBySpace)
+    loader.call({}, fixtures.componentWithTemplateUrlLast)
       .should
       .be
       .eql(`
@@ -204,8 +204,8 @@ describe("loader", function() {
 
   @Component({
     selector: 'test-component',
-    template: require('./some/path/to/file.html'), 
-    styles: [require('./app/css/styles.css')] 
+    styles: [require('./app/css/styles.css')],
+    template: require('./some/path/to/file.html')
   })
   export class TestComponent {}
 `

--- a/test/loader.spec.js
+++ b/test/loader.spec.js
@@ -222,8 +222,7 @@ describe("loader", function() {
 
   @Component({
     selector: 'test-component',
-    template: require('./some/path/to/file.html'), /*my awesome template*/
-    styles: [require('./app/css/styles.css')]
+    template: require('./some/path/to/file.html') /*my awesome template*/
   })
   export class TestComponent {}
 `

--- a/test/loader.spec.js
+++ b/test/loader.spec.js
@@ -212,7 +212,7 @@ describe("loader", function() {
 
   });
 
-  it("Should convert templateUrl properties there is a comment after them.", function() {
+  it("Should convert templateUrl properties when there is a comment after them.", function() {
 
     loader.call({}, fixtures.componentWithCommentAfterTemplateUrl)
       .should
@@ -230,4 +230,26 @@ describe("loader", function() {
 
   });
 
+  it("Should convert templateUrl properties when there is a comment between decorator and class.", function() {
+
+    loader.call({}, fixtures.componentWithCommentBetweenDecoratorAndClass)
+      .should
+      .be
+      .eql(`
+  import {Component} from '@angular/core';
+
+  @Component({
+    selector: 'test-component',
+    template: require('./some/path/to/file.html'),
+    styles: [require('./app/css/styles.css')]
+  })
+
+  /*  
+   * Comment
+   */
+  export class TestComponent  { }
+`
+      )
+
+  });
 });

--- a/test/loader.spec.js
+++ b/test/loader.spec.js
@@ -252,4 +252,23 @@ describe("loader", function() {
       )
 
   });
+
+  it("Should convert templateUrl properties when there is no styles or stylesUrl property.", function() {
+
+    loader.call({}, fixtures.componentWithOnlyTemplateUrl)
+      .should
+      .be
+      .eql(`
+  import {Component} from '@angular/core';
+
+  @Component({
+    selector: 'test-component',
+    template: require('./some/path/to/file.html')
+    //styles: [require('./app/css/styles.css')]
+  })
+  export class TestComponent {}
+`
+      )
+
+  });
 });

--- a/test/loader.spec.js
+++ b/test/loader.spec.js
@@ -194,4 +194,23 @@ describe("loader", function() {
 
   });
 
+  it("Should convert templateUrl properties when they appear last.", function() {
+
+    loader.call({}, fixtures.componentWithTemplateUrlEndingBySpace)
+      .should
+      .be
+      .eql(`
+  import {Component} from '@angular/core';
+
+  @Component({
+    selector: 'test-component',
+    template: require('./some/path/to/file.html'), 
+    styles: [require('./app/css/styles.css')] 
+  })
+  export class TestComponent {}
+`
+      )
+
+  });
+
 });

--- a/test/loader.spec.js
+++ b/test/loader.spec.js
@@ -193,7 +193,6 @@ describe("loader", function() {
       )
 
   });
-
   it("Should convert templateUrl properties when they appear last.", function() {
 
     loader.call({}, fixtures.componentWithTemplateUrlLast)
@@ -206,6 +205,25 @@ describe("loader", function() {
     selector: 'test-component',
     styles: [require('./app/css/styles.css')],
     template: require('./some/path/to/file.html')
+  })
+  export class TestComponent {}
+`
+      )
+
+  });
+
+  it("Should convert templateUrl properties there is a comment after them.", function() {
+
+    loader.call({}, fixtures.componentWithCommentAfterTemplateUrl)
+      .should
+      .be
+      .eql(`
+  import {Component} from '@angular/core';
+
+  @Component({
+    selector: 'test-component',
+    template: require('./some/path/to/file.html'), /*my awesome template*/
+    styles: [require('./app/css/styles.css')]
   })
   export class TestComponent {}
 `


### PR DESCRIPTION
I'm not sure if this is foolproof for all use cases this loaders is being used in. I've only tested it against my own app and saw it working. It simply makes the comma at the end of the line optional.

This will be a WIP until I get the tests passing.

If there are no downsides to this, then it should fix #50 and #58.