### PR TITLE
Use dummy context, update to loader-utils.getOptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,23 +18,16 @@ function replaceStringsWithRequires(string) {
 module.exports = function(source, sourcemap) {
 
   var config = {};
-  var query = loaderUtils.parseQuery(this.query);
+  Object.assign(config, loaderUtils.getOptions(this));
   var styleProperty = 'styles';
   var templateProperty = 'template';
-
-  if (this.options != null) {
-    Object.assign(config, this.options['angular2TemplateLoader']);
-  }
-
-  Object.assign(config, query);
 
   if (config.keepUrl === true) {
       styleProperty = 'styleUrls';
       templateProperty = 'templateUrl';
   }
-
-    // Not cacheable during unit tests;
-  this.cacheable && this.cacheable();
+  
+  this.cacheable();
 
   var newSource = source.replace(templateUrlRegex, function (match, url) {
                  // replace: templateUrl: './path/to/template.html'

--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
   },
   "homepage": "https://github.com/TheLarkInn/angular2-template-loader#readme",
   "devDependencies": {
-    "codecov": "^1.0.1",
-    "istanbul": "^0.4.3",
-    "mocha": "^2.5.3",
-    "should": "^9.0.0"
+    "codecov": "^3.0.0",
+    "istanbul": "^0.4.5",
+    "mocha": "^5.0.4",
+    "should": "^13.2.1"
   },
   "dependencies": {
-    "loader-utils": "^0.2.15"
+    "loader-utils": "^1.1.0"
   }
 }

--- a/test/loader.spec.js
+++ b/test/loader.spec.js
@@ -3,10 +3,42 @@ var loader = require("../index.js");
 
 var fixtures = require("./fixtures");
 
-describe("loader", function() {
+function getNewLoaderContext() {
+  return {
+    version: 2,
+    context: "",
+    request: "",
+    // query: any;
+    // callback: loaderCallback;
+    async: function(){ },
+    cacheable: function (flag) { },
+    loaders: ["angular2-template-loader"],
+    loaderIndex: 0,
+    resource: "",
+    resourcePath: "",
+    resourceQuery: "",
+    emitWarning: function(message) { },
+    emitError: function(message) { },
+    resolve: function(context, request, callback) { },
+    addDependency: function(file) { },
+    dependency: function(file) { },
+    dependency: function(file) { },
+    dependency: function(file) { },
+    dependency: function(file) { },
+    addContextDependency: function(directory) { },
+    clearDependencies: function() { },
+    sourceMap: true,
+    target: "",
+    webpack: true,
+    emitFile: function(name, content, sourceMap) {},
+    // fs: any,
+  }
+}
+
+describe("loader", function(){
   it("Should convert html and style file strings to require()s", function(){
 
-    loader.call({}, fixtures.simpleAngularTestComponentFileStringSimple)
+    loader.call(getNewLoaderContext(), fixtures.simpleAngularTestComponentFileStringSimple)
       .should
       .be
       .eql(`
@@ -25,7 +57,7 @@ describe("loader", function() {
 
   it("Should convert html and style file strings to require()s regardless of inner quotes", function(){
 
-    loader.call({}, fixtures.componentWithQuoteInUrls)
+    loader.call(getNewLoaderContext(), fixtures.componentWithQuoteInUrls)
       .should
       .be
       .eql(String.raw`
@@ -44,7 +76,7 @@ describe("loader", function() {
 
   it("Should convert html and multiple style file strings to require()s", function(){
 
-    loader.call({}, fixtures.componentWithMultipleStyles)
+    loader.call(getNewLoaderContext(), fixtures.componentWithMultipleStyles)
       .should
       .be
       .eql(`
@@ -65,21 +97,21 @@ describe("loader", function() {
   });
 
   it("Should return original source if there are no matches", function() {
-    loader.call({}, 'foo')
+    loader.call(getNewLoaderContext(), 'foo')
       .should
       .be
       .eql('foo');
   });
 
   it("Should convert partial string match requires", function() {
-    loader.call({}, `{templateUrl: './index/app.html'}`)
+    loader.call(getNewLoaderContext(), `{templateUrl: './index/app.html'}`)
       .should
       .be
       .eql(`{template: require('./index/app.html')}`);
   });
 
   it("Should handle the absense of proper relative path notation", function() {
-    loader.call({}, fixtures.componentWithoutRelPeriodSlash)
+    loader.call(getNewLoaderContext(), fixtures.componentWithoutRelPeriodSlash)
       .should
       .be
       .eql(`
@@ -97,7 +129,7 @@ describe("loader", function() {
 
   it("Should convert html and style file strings to require()s regardless of spacing", function(){
 
-    loader.call({}, fixtures.componentWithSpacing)
+    loader.call(getNewLoaderContext(), fixtures.componentWithSpacing)
       .should
       .be
       .eql(`
@@ -114,9 +146,10 @@ describe("loader", function() {
 
   });
 
-  it("Should keep templateUrl when asked for", function () {
-
-    loader.call({query: '?keepUrl=true'}, fixtures.componentWithSpacing)
+  it("Should keep templateUrl when asked using loader query", function () {
+    var context = getNewLoaderContext();
+    context.query = '?keepUrl=true';
+    loader.call(context, fixtures.componentWithSpacing)
       .should
       .be
       .eql(`
@@ -133,20 +166,13 @@ describe("loader", function() {
 
   });
 
-  it("Should keep templateUrl when asked using options", function () {
-
-    var self = {};
-
-    self.options = {
-      angular2TemplateLoader: {
-        keepUrl: true
-      }
-    };
-
-    loader.call(self, fixtures.componentWithSpacing)
-        .should
-        .be
-        .eql(`
+  it("Should keep templateUrl when asked using loader options", function () {
+    var context = getNewLoaderContext();
+    context.query = { keepUrl: true };
+    loader.call(context, fixtures.componentWithSpacing)
+      .should
+      .be
+      .eql(`
   import {Component} from '@angular/core';
 
   @Component({
@@ -156,13 +182,13 @@ describe("loader", function() {
   })
   export class TestComponent {}
 `
-        );
+      );
 
   });
 
   it("Should convert html and style file strings to require()s in a single line component decorator", function() {
 
-    loader.call({}, fixtures.componentWithSingleLineDecorator)
+    loader.call(getNewLoaderContext(), fixtures.componentWithSingleLineDecorator)
       .should
       .be
       .eql(`
@@ -177,7 +203,7 @@ describe("loader", function() {
 
   it("Should convert html and style file strings to require()s if line is ending by space character", function() {
 
-    loader.call({}, fixtures.componentWithTemplateUrlEndingBySpace)
+    loader.call(getNewLoaderContext(), fixtures.componentWithTemplateUrlEndingBySpace)
       .should
       .be
       .eql(`


### PR DESCRIPTION
Closes #75 by using getOptions, which can resolve a query string or an options object on the loader in newer versions of webpack.

Also provides a dummy LoaderContext for each test to remove the need for checking for the presence of this.cacheable or other properties.